### PR TITLE
Add support for Lights, Display Autoplay setting in test menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ stepx_*.sh
 
 *.iso
 *.zip
+*.swp
 
 
 # Byte-compiled / optimized / DLL files

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ All source code is included.
 
 
 ## KNOWN BUGS/ISSUES
-- Lights are not mapped correctly on solo cabinet (probably won't fix but I will accept a working PR)
 - Edits are bugged in 6 panel mode (won't fix)
+- Only one of the two sensors in each panel is read (won't fix)
 
 ## Instructions
 Note: **YOU MUST PROVIDE YOUR OWN DATA!**
@@ -36,9 +36,9 @@ If you are building using *nix, you must compile the required Cython modules:
 
 ## Notes
 - Dipswitch 1 can be toggled on/off to enable/disable autoplay (even on real hardware)
-- There are various flags in [src/main.asm](https://github.com/987123879113/sys573mods/blob/main/ddr5thmix-solo-src/src/main.asm) that can be modified such as `FORCE_UNLOCK`, `SOLO_MODE`, `AUTOPLAY_ENABLED`, `AUTOPLAY_TIMING`, `DISABLE_ANNOUNCER`, and `DISABLE_CHEERING`.
+- There are various flags in [src/main.asm](https://github.com/987123879113/sys573mods/blob/main/ddr5thmix-solo-src/src/main.asm) that can be modified such as `FORCE_UNLOCK`, `SOLO_MODE`, `AUTOPLAY_ENABLED`, `AUTOPLAY_TIMING`, `DISABLE_ANNOUNCER`, `DISABLE_CHEERING`, and `SWAP_EXTRA_LIGHTS`.
 
 ## Thanks
 - @WannyTiggah for the edited title screen and icon edits
 - @SakamotoNeko13 for the edited 4PANEL/6PANEL graphics on the style select screen
-- @dragonminded for testing with a real Solo cabinet
+- @dragonminded for testing with a real Solo cabinet as well as lights mapping, lights test menu and autoplay display on dip test menu

--- a/src/autoplay.asm
+++ b/src/autoplay.asm
@@ -32,3 +32,35 @@ CheckAutoplayDipswitchEnd:
 ; Default is 16 which will result in a mix of perfect and marvelous judgements
 ; 2 may possibly be a bit tight on real hardware, but MAX 300 is a pain and you get 1 or 2 goods at the end with a value of 4
     slti v0, s2, AUTOPLAY_TIMING
+
+.org 0x80012a24
+; Display "AUTOPLAY" as DIP1 setting on the DIP switch test menu.
+    .asciiz "SW1  AUTOPLAY"
+
+.org 0x80012d2c
+OffText:
+.org 0x80012d3c
+OnText:
+
+.org 0x80039bc8
+    j ComputeAutoplayOnOff
+    nop
+ComputeAutoplayFinished:
+
+.org 0x80012b8c
+; Display "ON" or "OFF" depending on whether autoplay is on or off, on the DIP switch test menu.
+ComputeAutoplayOnOff:
+    andi v0, s3, 0x1
+    beq v0, zero, _ComputeDisplayOn
+    nop
+    li v0, OffText
+    jal draw_text
+    sw v0, 0x14(sp)
+    j ComputeAutoplayFinished
+    nop
+_ComputeDisplayOn:
+    li v0, OnText
+    jal draw_text
+    sw v0, 0x14(sp)
+    j ComputeAutoplayFinished
+    nop

--- a/src/main.asm
+++ b/src/main.asm
@@ -39,6 +39,12 @@
 ;  0 = Off
 ;  1 = On
 .definelabel DISABLE_CHEERING, 0
+
+; Swap EXTRA1/2/3/4 mapping. Some cabinets start with EXTRA1 as the front left, then
+; EXTRA2 as the back left, then EXTRA3 as the front right, and finally EXTRA4 as the
+; back right. If your cabinet is like this, set the below label to 1. If your cabinet
+; goes top to bottom right to left, then leave this set to 0.
+.definelabel SWAP_EXTRA_LIGHTS, 0
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 

--- a/src/solo.asm
+++ b/src/solo.asm
@@ -487,6 +487,7 @@ InputTestMenuEnd:
 .org 0x8009a328
     bne s0, v0, 0x8009a330
 
+.if SWAP_EXTRA_LIGHTS == 1
 ; Turn on extra2 (left back) when left is pressed.
 .org 0x8009a0c8
     li a0, 0x7
@@ -516,6 +517,37 @@ InputTestMenuEnd:
     li a0, 0x4
 .org 0x8009a168
     li a0, 0x4
+.else
+; Turn on extra4 (left back) when left is pressed.
+.org 0x8009a0c8
+    li a0, 0x5
+
+; Turn on extra2 (right back) when right is pressed.
+.org 0x8009a078
+    li a0, 0x7
+.org 0x8009a094
+    li a0, 0x7
+
+; Turn on extra3 (left front) when up-left is pressed.
+.org 0x8009a19c
+    li a0, 0x4
+.org 0x8009a1b8
+    li a0, 0x4
+.org 0x8009a1d0
+    li a0, 0x4
+.org 0x8009a1ec
+    li a0, 0x4
+
+; Turn on extra1 (right front) when up-right is pressed.
+.org 0x8009a118
+    li a0, 0x6
+.org 0x8009a134
+    li a0, 0x6
+.org 0x8009a14c
+    li a0, 0x6
+.org 0x8009a168
+    li a0, 0x6
+.endif
 
 ; Turn on extra1 and 3 (both forward lights) when up is pressed.
 .org 0x8009a028

--- a/src/solo.asm
+++ b/src/solo.asm
@@ -354,9 +354,12 @@ InputTestMenuEnd:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Lights Test Menu
 
-; Fixes unable to select individual lights for test.
+; Fixes unable to select individual lights for test. The original "is held" function
+; is nop'd out above, so we must give a negative index to this function to turn it
+; into a held function.
 .org 0x80039f44
     jal is_1p_start_pressed
+    li a0, -0x4
 
 ; Mapping from which test light entry to which actual light to activate.
 .org 0x80012acc

--- a/src/solo.asm
+++ b/src/solo.asm
@@ -345,3 +345,132 @@ InputTestMenuEnd:
 .org 0x8003c244
     ; Coin Mech ON/OFF
     li a2, 0x2a
+
+.org 0x80012d30
+    ; Don't display ULDR next to ON/OFF for IO test since Solo has no IO board.
+    .asciiz "%s"
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Lights Test Menu
+
+; Fixes unable to select individual lights for test.
+.org 0x80039f44
+    jal is_1p_start_pressed
+
+; Mapping from which test light entry to which actual light to activate.
+.org 0x80012acc
+    ; Body left/center/right lights.
+    .dw 12
+    .dw 9
+    .dw 8
+    ; Pad extra1/extra2/extra3/extra4 lights.
+    .dw 6
+    .dw 7
+    .dw 4
+    .dw 5
+    ; Start button light.
+    .dw 14
+    ; Speaker light.
+    .dw 16
+
+; Labels for the lights test options.
+.org 0x80012b08
+    .asciiz "BODY LEFT"
+.org 0x80012b14
+    .asciiz "BODY CENTER"
+.org 0x80012b24
+    .asciiz "BODY RIGHT"
+.org 0x80012b34
+    .asciiz "EXTRA1"
+.org 0x80012b44
+    .asciiz "EXTRA2"
+.org 0x80012b50
+    .asciiz "EXTRA3"
+.org 0x80012b60
+    .asciiz "EXTRA4"
+.org 0x80012b70
+    .asciiz "START"
+.org 0x80012b80
+    .asciiz "SPEAKER"
+
+; Skip displaying labels for lamps we don't have.
+.org 0x8003a19c
+    nop
+.org 0x8003a1c0
+    nop
+.org 0x8003a1e4
+    nop
+.org 0x8003a208
+    nop
+.org 0x8003a22c
+    nop
+.org 0x8003a250
+    nop
+
+; Reposition "ALL" and "EXIT" according to the new layout.
+.org 0x8003a25c
+    li a2, 0x0
+.org 0x8003a280
+    li a2, 0x10
+
+; Reference the correct cursor value for "ALL" and "EXIT".
+.org 0x8003a270
+    lw a0, 0x3c(sp)
+.org 0x8003a294
+    lw a0, 0x40(sp)
+
+; Check for the correct cursor value to display green "current light" indicator
+; if we are doing the "ALL" check.
+.org 0x8003a010
+    li v0, 0x9
+
+; Wrap cursor around from top to bottom correctly.
+.org 0x80039e14
+    li v0, 0xA
+
+; Wrap cursor around from bottom to top correctly.
+.org 0x80039e44
+    slti v0, v0, 0xB
+
+; Run all test when "ALL" is selected.
+.org 0x80039e78
+    li v0, 0x9
+.org 0x80039f60
+    li v0, 0x9
+
+; Exit when "EXIT" is selected.
+.org 0x80039f04
+    li v0, 0xA
+.org 0x80039f50
+    li v0, 0xA
+
+; Initialize the all test frame counter to account for us only having 9 lights
+; instead of 15, accounting for 60 frames per light being lit.
+.org 0x80039f6c
+    li v0, 0x21C
+.org 0x80039ea4
+    li v0, 0x21B
+.org 0x80039ebc
+    li a1, 0x8
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Lights mappings
+
+; Map body right lower to body left, right higher and left lower to body center, and left higher to body right.
+.org 0x8001666c
+    .dw 0x00000002
+    .dw 0x00000200
+.org 0x80016664
+    .dw 0x00000002
+    .dw 0x00000400
+
+; Map start 1p to correct solo start lights.
+.org 0x8001667c
+    .dw 0x00000002
+    .dw 0x00000100
+
+; Fix "speaker" light output to point at solo speaker neons.
+.org 0x8001668c
+    .dw 0x00000002
+    .dw 0x00001000

--- a/src/solo.asm
+++ b/src/solo.asm
@@ -474,3 +474,62 @@ InputTestMenuEnd:
 .org 0x8001668c
     .dw 0x00000002
     .dw 0x00001000
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Lights activation functions for panel steppy
+
+; Turn on all body lights when requested to isntead of 1P/2P side only.
+.org 0x8009a304
+    beq v0, zero, 0x8009a30c
+.org 0x8009a328
+    bne s0, v0, 0x8009a330
+
+; Turn on extra2 (left back) when left is pressed.
+.org 0x8009a0c8
+    li a0, 0x7
+
+; Turn on extra4 (right back) when right is pressed.
+.org 0x8009a078
+    li a0, 0x5
+.org 0x8009a094
+    li a0, 0x5
+
+; Turn on extra1 (left front) when up-left is pressed.
+.org 0x8009a19c
+    li a0, 0x6
+.org 0x8009a1b8
+    li a0, 0x6
+.org 0x8009a1d0
+    li a0, 0x6
+.org 0x8009a1ec
+    li a0, 0x6
+
+; Turn on extra3 (right front) when up-right is pressed.
+.org 0x8009a118
+    li a0, 0x4
+.org 0x8009a134
+    li a0, 0x4
+.org 0x8009a14c
+    li a0, 0x4
+.org 0x8009a168
+    li a0, 0x4
+
+; Turn on extra1 and 3 (both forward lights) when up is pressed.
+.org 0x8009a028
+    li a0, 0x6
+.org 0x8009a044
+    li a0, 0x4
+.org 0x8009a01c
+    beq v0, zero, 0x8009a024
+.org 0x8009a038
+    bne s0, v0, 0x8009a040
+
+; Turn on extra2 and 4 (both back lights) when down is pressed.
+.org 0x80099fd8
+    li a0, 0x7
+.org 0x80099ff4
+    li a0, 0x5
+.org 0x80099fcc
+    beq v0, zero, 0x80099fd4
+.org 0x80099fe8
+    bne s0, v0, 0x80099ff0

--- a/step1_extract.sh
+++ b/step1_extract.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+set -e
+
 mkdir -p data_raw
 python3 tools/py/dump_sys573_gamefs.py --input data_source --output data_raw --key DDR5 --type ddr --input-filenames tools/ddr5th_filenames.json

--- a/step2_make.sh
+++ b/step2_make.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 mkdir -p build
 
 cp -r data_source/* build

--- a/step2_make_soloio.sh
+++ b/step2_make_soloio.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 mkdir -p build
 
 cp -r data_source/* build


### PR DESCRIPTION
This pull request does so many things:

 - Makes the lights test menu functional again (it was broken by the patch to disable 2P start).
 - Recodes the lights test menu to match solo lights instead of doubles lights.
 - Maps foot switch presses to correct EXTRA1/2/3/4 lights in-game.
 - Maps speaker to the top neon, the four body lights to the center solo body lights, and the start lights.
 - Adds display of autoplay setting to DIP switch test menu (if autoplay patches are enabled).
 - Hides UDLR display on I/O test menu because Solo does not have a stage I/O.
 - Fixes *NIX build scripts to exit on failure instead of continuing and burying the error message.